### PR TITLE
Renew rspec syntax

### DIFF
--- a/lib/bahtera.rb
+++ b/lib/bahtera.rb
@@ -8,7 +8,7 @@ module Bahtera
   class RequestError < StandardError; end
 
   class << self
-    BASE_URL    = "http://kateglo.bahtera.org/api.php"
+    BASE_URL    = "http://kateglo.com/api.php"
     BASE_PARAMS = { format: 'json' }
 
     def lookup(lemma)

--- a/spec/bahtera_spec.rb
+++ b/spec/bahtera_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe Bahtera do
   describe '#lookup' do
     it 'should respond to #lookup' do
-      Bahtera.should respond_to(:lookup)
+      expect(Bahtera).to respond_to(:lookup)
     end
 
     it 'should send request to the correct address' do
       word = 'makan'
-      Net::HTTP.should_receive(:get_response).
+      expect(Net::HTTP).to receive(:get_response).
               with(Addressable::URI.parse("#{Bahtera.singleton_class::BASE_URL}?format=json&phrase=#{word}")).
               and_return(stub_net_http_success('bahtera_kata_valid'))
       Bahtera.lookup word
@@ -21,20 +21,20 @@ describe Bahtera do
 
       it '#lookup a valid word should return an instance of Bahtera::Kata' do
         word = 'kata'
-        Bahtera.lookup(word).should be_a(Bahtera::Kata)
+        expect(Bahtera.lookup(word)).to be_kind_of(Bahtera::Kata)
       end
 
       it '#lookup many valid words should return an array of Bahtera::Kata instances' do
         results = Bahtera.lookup('minum makan belajar')
-        results.should be_a(Array)
-        results.all? { |r| r.is_a?(Bahtera::Kata) }.should be_true
+        expect(results).to be_kind_of(Array)
+        results.each { |r| expect(r.is_a?(Bahtera::Kata)).to be true }
       end
     end
 
     it '#lookup invalid words should raise MultiJson::LoadError' do
       stub_net_http('bahtera_kata_invalid')
       word = 'invalid_kata'
-      Bahtera.lookup(word).should be_a(Bahtera::LemmaNotFound)
+      expect(Bahtera.lookup(word)).to be_kind_of(Bahtera::LemmaNotFound)
     end
 
     it '#lookup mix of invalid & valid words returns an array of LemmaNotFound & Kata instances' do
@@ -43,14 +43,14 @@ describe Bahtera do
         gwempor:  'bahtera_kata_invalid'
       }
       word_hash.each do |word, filename|
-        Net::HTTP.stub(:get_response).
+        allow(Net::HTTP).to receive(:get_response).
           with(Addressable::URI.parse("#{Bahtera.singleton_class::BASE_URL}?format=json&phrase=#{word}")).
           and_return(stub_net_http_success(filename))
       end
       results = Bahtera.lookup('kata gwempor')
-      results.should be_a(Array)
-      results.first.should be_a(Bahtera::Kata)
-      results.last.should be_a(Bahtera::LemmaNotFound)
+      expect(results).to be_kind_of(Array)
+      expect(results.first).to be_kind_of(Bahtera::Kata)
+      expect(results.last).to be_kind_of(Bahtera::LemmaNotFound)
     end
 
     describe 'should raise Bahtera::RequestError when' do

--- a/spec/bahtera_spec.rb
+++ b/spec/bahtera_spec.rb
@@ -9,7 +9,7 @@ describe Bahtera do
     it 'should send request to the correct address' do
       word = 'makan'
       Net::HTTP.should_receive(:get_response).
-              with(Addressable::URI.parse("http://kateglo.bahtera.org/api.php?format=json&phrase=#{word}")).
+              with(Addressable::URI.parse("#{Bahtera.singleton_class::BASE_URL}?format=json&phrase=#{word}")).
               and_return(stub_net_http_success('bahtera_kata_valid'))
       Bahtera.lookup word
     end
@@ -44,7 +44,7 @@ describe Bahtera do
       }
       word_hash.each do |word, filename|
         Net::HTTP.stub(:get_response).
-          with(Addressable::URI.parse("http://kateglo.bahtera.org/api.php?format=json&phrase=#{word}")).
+          with(Addressable::URI.parse("#{Bahtera.singleton_class::BASE_URL}?format=json&phrase=#{word}")).
           and_return(stub_net_http_success(filename))
       end
       results = Bahtera.lookup('kata gwempor')

--- a/spec/lib/bahtera/kata_spec.rb
+++ b/spec/lib/bahtera/kata_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Bahtera::Kata do
   describe '#initialize' do
     it 'should initialize from valid json string' do
-      Bahtera::Kata.new(parsed_fixture_file('bahtera_kata_valid')).should be_a(Bahtera::Kata)
+      expect(Bahtera::Kata.new(parsed_fixture_file('bahtera_kata_valid'))).to be_kind_of(Bahtera::Kata)
     end
 
     it 'should raise MultiJson::LoadError when initializing from invalid json string' do
@@ -26,21 +26,21 @@ describe Bahtera::Kata do
           next
         end
         it "should assign ##{attr_name} correctly" do
-          @kata.send(attr_name).should == @expected_attributes[attr_name]
+          expect(@kata.send(attr_name)).to eq(@expected_attributes[attr_name])
         end
       end
 
       array_attributes.each do |attr_name, array|
         it "##{attr_name} should transform to the array of Bahtera::BaseKata" do
           @kata.send(attr_name).all? do |entry|
-            entry.is_a?(Bahtera::BaseKata)
-          end.should be_true
+            expect(entry.is_a?(Bahtera::BaseKata)).to be true
+          end
         end
 
         it "should respond_to #has_#{attr_name}?" do
           method_name = "has_#{attr_name}?"
-          @kata.should respond_to(method_name)
-          @kata.send(method_name).should == @expected_attributes[attr_name].any?
+          expect(@kata).to respond_to(method_name)
+          expect(@kata.send(method_name)).to eq(@expected_attributes[attr_name].any?)
         end
       end
 
@@ -49,8 +49,8 @@ describe Bahtera::Kata do
           has_method_name = "has_#{attr_name}?"
 
           it "should respond to ##{attr_name} & ##{has_method_name}" do
-            @kata.should respond_to(attr_name)
-            @kata.should respond_to(has_method_name)
+            expect(@kata).to respond_to(attr_name)
+            expect(@kata).to respond_to(has_method_name)
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ def stub_net_http(filename = nil, code = nil)
   else
     stub_net_http_error(code)
   end
-  Net::HTTP.stub(:get_response).and_return(response)
+  allow(Net::HTTP).to receive(:get_response).and_return(response)
 end
 
 def stub_net_http_success(filename)


### PR DESCRIPTION
- Use rspec recommended `:expect` method to replace the now deprecated `:should`.
  <br />\* Change `stub` from rspec-mocks' old `:should` syntax to `:allow`.
